### PR TITLE
[S_Ref] reagent_property_data_Pubchem.py

### DIFF
--- a/service/dataset/reagent_property_data_Pubchem.py
+++ b/service/dataset/reagent_property_data_Pubchem.py
@@ -140,26 +140,33 @@ def get_CAS(cid):
 
 
 def get_Table_data(name):
-    dict_properties = get_PropertyTable_data(name)
-    CID = dict_properties.pop("CID")
-    file_data = {}
-    colunm_list = ["casNo", "name" , "formula" ,"molecularWeight" , "meltingpoint" , "boilingpoint" ,"density"]
-    file_data[colunm_list[0]] = get_CAS(CID)
-    file_data[colunm_list[1]] = get_commonname(CID)
-    file_data[colunm_list[2]] = dict_properties['MolecularFormula']
-    file_data[colunm_list[3]] = str(dict_properties['MolecularWeight'])
-    file_data[colunm_list[4]] = get_MeltingPoint(CID)
-    file_data[colunm_list[5]] = get_BoilingPoint(CID)
-    file_data[colunm_list[6]] = get_Density(CID)
+    try :
+        dict_properties = get_PropertyTable_data(name)
+        CID = dict_properties.pop("CID")
+        file_data = {}
+        colunm_list = ["casNo", "name" , "formula" ,"molecularWeight" , "meltingpoint" , "boilingpoint" ,"density"]
+        file_data[colunm_list[0]] = get_CAS(CID)
+        file_data[colunm_list[1]] = get_commonname(CID)
+        file_data[colunm_list[2]] = dict_properties['MolecularFormula']
+        file_data[colunm_list[3]] = str(dict_properties['MolecularWeight'])
+        file_data[colunm_list[4]] = get_MeltingPoint(CID)
+        file_data[colunm_list[5]] = get_BoilingPoint(CID)
+        file_data[colunm_list[6]] = get_Density(CID)
+
+    except:
+        file_data = [name]
     return file_data
 
 
 def get_query(name):
-    url = 'https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/%s/synonyms/json' %name
-    jsonfile = recall_json_api(url)
-    query_list = jsonfile.get("InformationList").get("Information")[0].get("Synonym")
+    try:
+        url = 'https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/%s/synonyms/json' %name
+        jsonfile = recall_json_api(url)
+        query_list = jsonfile.get("InformationList").get("Information")[0].get("Synonym")
+    except:
+        query_list = None
     return query_list
 
 
 # print(get_query("Water"))
-# print(get_Table_data("Water"))
+# print(get_Table_data("water"))

--- a/service/dataset/reagent_property_data_Pubchem.py
+++ b/service/dataset/reagent_property_data_Pubchem.py
@@ -154,7 +154,7 @@ def get_Table_data(name):
         file_data[colunm_list[6]] = get_Density(CID)
 
     except:
-        file_data = [name]
+        file_data = None
     return file_data
 
 
@@ -168,5 +168,6 @@ def get_query(name):
     return query_list
 
 
-# print(get_query("Water"))
+#  print(ge4rt_query("Water"))
 # print(get_Table_data("water"))
+# print(get_Table_data("wat"))


### PR DESCRIPTION
 get_Table_data 함수에서 만약 pubchem에 데이터가 없는 물질명('wat')이 입력되었을 때 ['wat']을 return하도록 설정 하였습니다. 따라서 frontend에서 구현할 때 만약 리스트 형태의 값이 return되었다면 table에 넣지 않고 아래에 추가로 데이터가 없음을 나타내주면 될 것 같습니다.(데이터가 존재할 때의 data type은 딕셔너리)
get_query 함수의 경우 만약 잘못된 물질명이 입력되면 None값이 return 되도록 하였습니다.(데이터가 존재할 때의 data type은 리스트)